### PR TITLE
feat(student-profile): add warning for resume drive link access

### DIFF
--- a/pages/grow-your-resume/student/profile.tsx
+++ b/pages/grow-your-resume/student/profile.tsx
@@ -454,6 +454,9 @@ const ProfilePage = () => {
                                             </div>
                                         )}
                                         <p className="text-sm text-gray-500 mt-1">Link to your resume (Google Drive, Dropbox, etc.)</p>
+                                        <p className="text-sm text-red-500 font-medium mt-2">
+                                            Note: Please ensure your Drive link access is set to &apos;Anyone with the link can view&apos;. Startups will reject your application if they cannot open your resume.
+                                        </p>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Description
This PR addresses Task 1 for the student-facing experience by adding a warning callout below the Resume Link input on the Student Profile page.

### Changes Made
- Modified `pages/grow-your-resume/student/profile.tsx` to include a prominent warning message below the resume link field.
- The warning instructs students to ensure their Google Drive link access is set to "Anyone with the link can view" to prevent recruiters from rejecting their application due to accessibility issues.
