### PR TITLE
fix(lottie): use next/script to prevent duplicate CustomElementRegitory errors

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import Script from "next/script";
 import { Collage, CollagePhone } from "../components/Collage";
 import { Container, Row, Col, Button, Card } from "react-bootstrap";
 import Footer from "../components/Footer";
@@ -418,18 +419,14 @@ export default function Home() {
           <Footer />
         </Container>
       </div>
-      <script
-        async
+      <Script
         src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"
-      ></script>
-      <script
-        async
+        strategy="lazyOnload"
+      />
+      <Script
         src="https://unpkg.com/@dotlottie/player-component@latest/dist/dotlottie-player.js"
-      ></script>
-      <script
-        async
-        src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"
-      ></script>
+        strategy="lazyOnload"
+      />
     </>
   );
 }


### PR DESCRIPTION
## Description
This PR fixes a critical frontend crash on the homepage caused by `lottie-player` being defined multiple times as a custom element (frequently triggered during hot-reloads and client-side routing).

### Changes Made
- Refactored `pages/index.js` to replace raw HTML `<script>` tags with Next.js's optimized `next/script` component.
- Removed duplicate script imports for the Lottie and DotLottie players to prevent the `CustomElementRegistry.define` crash.
