### PR TITLE
fix: recruiter post creation failing due to disabled data loading

### DIFF
--- a/pages/grow-your-resume/recruiter/post-internship.tsx
+++ b/pages/grow-your-resume/recruiter/post-internship.tsx
@@ -45,8 +45,6 @@ const PostInternshipPage = () => {
     const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
 
     useEffect(() => {
-        setLoading(false);
-        return;
 
         const loadRecruiterData = async () => {
             try {


### PR DESCRIPTION
Found and fixed a bug in post-internship.tsx: a `return;` statement 
   right after setLoading(false) in the useEffect was preventing 
   loadRecruiterData() from ever running, so currentRecruiter.id 
   always stayed empty, causing "Invalid recruiterId" errors on 
   post creation.
   
   Fix: removed the early return so recruiter data loads correctly.
   
   Tested: confirmed recruiterId now populates correctly, post 
   successfully created and visible in Supabase.